### PR TITLE
Fritz Lab will be developing and maintaining Parliament2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+# Parliament2 is currently maintained and developed by [Fritz Sedlazeck Lab](https://fritzsedlazeck.github.io) as of Nov. 2020. Please use [this repository](https://github.com/fritzsedlazeck/parliament2) for the latest developement and issue tracking of Parliament2. This repo is read-only for archiving purpose. 
+ 
+
 # Parliament2 ![CI Badge](https://travis-ci.org/dnanexus/parliament2.svg?branch=master)
 
 Parliament2 identifies structural variants in a given sample relative to a reference genome. These structural variants cover large deletion events that are called as Deletions of a region, Insertions of a sequence into a region, Duplications of a region, Inversions of a region, or Translocations between two regions in the genome.


### PR DESCRIPTION
Fritz Lab will be developing and maintaining Parliament2. Add the link to Fritz's lab repo. We are moving this repo into read-only mode.